### PR TITLE
[INF-8900] Better control plane health wait

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.3.4-alpha-plaid
+0.3.4-plaid-2

--- a/pkg/reaper/nodereaper/helpers.go
+++ b/pkg/reaper/nodereaper/helpers.go
@@ -504,7 +504,7 @@ func isControlPlane(node string, kubeClient kubernetes.Interface) (bool, error) 
 		return false, err
 	}
 	labels := nodeObject.ObjectMeta.GetLabels()
-	if labels[controlPlaneNodeLabel] == "" {
+	if _, ok := labels[controlPlaneNodeLabel]; ok {
 		return true, nil
 	}
 	return false, nil

--- a/pkg/reaper/nodereaper/helpers.go
+++ b/pkg/reaper/nodereaper/helpers.go
@@ -50,6 +50,7 @@ const (
 	nodeSelectorNode         NodeSelector = "node-role.kubernetes.io/node="
 	nodeSelectorControlPlane NodeSelector = "node-role.kubernetes.io/control-plane="
 	controlPlaneNodeLabel    string       = "node-role.kubernetes.io/control-plane"
+	workerNodeLabel          string       = "node-role.kubernetes.io/node"
 	lockTableClusterIDKey                 = "ClusterID"
 )
 
@@ -527,7 +528,7 @@ func getHealthyMasterCount(kubeClient kubernetes.Interface) (int, error) {
 	return masterCount, nil
 }
 
-func (ctx *ReaperContext) waitForNodesReady() error {
+func (ctx *ReaperContext) waitForControlPlaneReady() error {
 	var controlPlaneCheckError error
 	// Do not release the lock until control plane is healthy
 	controlPlaneHealthCheckStart := time.Now()
@@ -606,6 +607,7 @@ func (ctx *ReaperContext) controlPlaneReady() (bool, error) {
 }
 
 func (ctx *ReaperContext) deleteKubernetesNode(nodeName string) error {
+	log.Infof("deleting node %s from Kubernetes", nodeName)
 	return ctx.KubernetesClient.CoreV1().Nodes().Delete(nodeName, &metav1.DeleteOptions{})
 }
 

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -730,6 +730,12 @@ func (ctx *ReaperContext) reapUnhealthyNodes(w ReaperAwsAuth) error {
 					return err
 				}
 
+				// termination call was successful, so we can try to delete the node from the API
+				err = ctx.deleteKubernetesNode(instance.NodeName)
+				if err != nil {
+					log.Warnf("failed to delete the node %v: %v", instance.NodeName, err)
+				}
+
 				// Throttle deletion
 				ctx.TerminatedInstances++
 				ctx.exposeMetric(instance.NodeName, instance.InstanceID, terminationReasonUnhealthy, NodeReaperResultMetricName, float64(ctx.TerminatedInstances))

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -96,6 +96,8 @@ func (ctx *ReaperContext) validateArguments(args *Args) error {
 		ctx.ReapTainted = append(ctx.ReapTainted, taint)
 	}
 
+	log.Infof("Reap Tainted = %q", ctx.ReapTainted)
+
 	if ctx.MaxKill < 1 {
 		err := fmt.Errorf("--max-kill-nodes must be set to a number greater than or equal to 1")
 		log.Errorln(err)

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -84,6 +85,7 @@ func (ctx *ReaperContext) validateArguments(args *Args) error {
 	log.Infof("ASG Validation = %t", ctx.AsgValidation)
 	log.Infof("Post Reap Throttle = %v seconds", ctx.ReapThrottle)
 
+	reapTaintedLog := []string{}
 	for _, t := range args.ReapTainted {
 		var taint v1.Taint
 		var ok bool
@@ -94,9 +96,12 @@ func (ctx *ReaperContext) validateArguments(args *Args) error {
 		}
 
 		ctx.ReapTainted = append(ctx.ReapTainted, taint)
+		reapTaintedLog = append(reapTaintedLog, taint.ToString())
 	}
 
-	log.Infof("Reap Tainted = %q", ctx.ReapTainted)
+	if len(ctx.ReapTainted) > 0 {
+		log.Infof("Reap Tainted = %s", strings.Join(reapTaintedLog, ","))
+	}
 
 	if ctx.MaxKill < 1 {
 		err := fmt.Errorf("--max-kill-nodes must be set to a number greater than or equal to 1")

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -242,6 +242,9 @@ func (ctx *ReaperContext) validateArguments(args *Args) error {
 
 		ctx.ClusterID = args.ClusterID
 		ctx.LocksTableName = args.LocksTableName
+
+		log.Infof("Cluster ID = %s", ctx.ClusterID)
+		log.Infof("Locks Table Name = %s", ctx.LocksTableName)
 	}
 
 	return nil
@@ -534,7 +537,7 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 		if isControlPlaneNode {
 			if masterCount < ctx.ControlPlaneNodeCount {
 				log.Infof("%v", masterCount)
-				log.Infof("less than 3 healthy master nodes, skipping %v", instance.NodeName)
+				log.Infof("less than %d healthy master nodes, skipping %v", ctx.ControlPlaneNodeCount, instance.NodeName)
 				continue
 			}
 		}
@@ -550,7 +553,7 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 				continue
 			}
 
-			nodesReady, err := allNodesAreReady(ctx.KubernetesClient, nodeSelectorAll)
+			nodesReady, err := ctx.allNodesAreReady()
 			if err != nil {
 				return err
 			}

--- a/pkg/reaper/nodereaper/nodereaper_test.go
+++ b/pkg/reaper/nodereaper/nodereaper_test.go
@@ -230,8 +230,10 @@ func createNodeLabels(node FakeNode, ctx *ReaperContext) map[string]string {
 	nodeLabels := make(map[string]string)
 	if node.isMaster {
 		nodeLabels["kubernetes.io/role"] = "master"
+		nodeLabels[controlPlaneNodeLabel] = ""
 	} else {
 		nodeLabels["kubernetes.io/role"] = "node"
+		nodeLabels[workerNodeLabel] = ""
 	}
 
 	for key, value := range node.nodeLabels {
@@ -1335,13 +1337,13 @@ func TestIgnoreFailure(t *testing.T) {
 		},
 		Nodes: []FakeNode{
 			{
-				nodeName: "ip-10-10-10-10.us-west-2.compute.local",
-				state:    "NotReady",
+				nodeName:   "ip-10-10-10-10.us-west-2.compute.local",
+				state:      "NotReady",
 				ageMinutes: 43200,
 			},
 			{
-				nodeName: "ip-10-10-10-11.us-west-2.compute.local",
-				state: 		"Unknown",
+				nodeName:   "ip-10-10-10-11.us-west-2.compute.local",
+				state:      "Unknown",
 				ageMinutes: 43200,
 			},
 			{
@@ -1363,11 +1365,11 @@ func TestIgnoreFailure(t *testing.T) {
 				kind:   "Node",
 			},
 		},
-		FakeReaper:				reaper,
-		ExpectedUnready:    	3,
-		ExpectedOldReapable:	3,
-		ExpectedDrainable:  	0,
-		ExpectedDrained:    	0,
+		FakeReaper:          reaper,
+		ExpectedUnready:     3,
+		ExpectedOldReapable: 3,
+		ExpectedDrainable:   0,
+		ExpectedDrained:     0,
 	}
 	testCase.Run(t, false)
 }
@@ -1726,7 +1728,6 @@ func TestRegionDetection(t *testing.T) {
 		t.Fatalf("expected Region: %v, got: %v", expectedRegion, providerRegion)
 	}
 }
-
 
 func TestSkipLabelReaper(t *testing.T) {
 	reaper := newFakeReaperContext()


### PR DESCRIPTION
Governor marks master nodes as unschedulable, but does not delete them from the k8s API before terminating the EC2 instance. Thus, it takes time for the termination to reflect in the API. Counting unschedulable masters as unhealthy should help.
~~Alternatively, governor could delete the node from the API? I think as long as the AWS EC2 API call returned OK for termination the node is going down so there's no need to keep it in the API 🤔~~ Updated to delete nodes.