### PR TITLE
Move the deletion throttle sleep outside of the control plane lock loop to prevent holding lease too long

### DIFF
--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -635,8 +635,6 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 				ctx.TerminatedInstances++
 				ctx.exposeMetric(instance.NodeName, instance.InstanceID, terminationReasonHealthy, NodeReaperResultMetricName, float64(ctx.TerminatedInstances))
 
-				log.Infof("starting deletion throttle wait -> %vs", ctx.AgeReapThrottle)
-				time.Sleep(time.Second * time.Duration(ctx.AgeReapThrottle))
 			} else {
 				log.Warnf("dry run is on, '%v' will not be terminated", instance.NodeName)
 			}
@@ -657,6 +655,9 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 		if err != nil {
 			return err
 		}
+
+		log.Infof("starting deletion throttle wait -> %vs", ctx.AgeReapThrottle)
+		time.Sleep(time.Second * time.Duration(ctx.AgeReapThrottle))
 	}
 	log.Infof("reap cycle completed, terminated %v instances", ctx.TerminatedInstances)
 	return nil

--- a/pkg/reaper/nodereaper/nodereaper.go
+++ b/pkg/reaper/nodereaper/nodereaper.go
@@ -656,8 +656,10 @@ func (ctx *ReaperContext) reapOldNodes(w ReaperAwsAuth) error {
 			return err
 		}
 
-		log.Infof("starting deletion throttle wait -> %vs", ctx.AgeReapThrottle)
-		time.Sleep(time.Second * time.Duration(ctx.AgeReapThrottle))
+		if !ctx.DryRun {
+			log.Infof("starting deletion throttle wait -> %vs", ctx.AgeReapThrottle)
+			time.Sleep(time.Second * time.Duration(ctx.AgeReapThrottle))
+		}
 	}
 	log.Infof("reap cycle completed, terminated %v instances", ctx.TerminatedInstances)
 	return nil


### PR DESCRIPTION
Currently, we hang after deleting a node for the age reap threshold instead of polling for its readiness and then releasing the lock.

This results in us timing out our governor jobs because we end up waiting a super long time and never actually allowing other jobs to take on the lock and rotate their masters.

This shouldn't cause any issues because we poll for the readiness of the control plane before moving forward with any deletions.